### PR TITLE
refactor: replace deprecated axios.CancelToken with AbortController

### DIFF
--- a/src/components/Vuetify/VqDataTable/index.tsx
+++ b/src/components/Vuetify/VqDataTable/index.tsx
@@ -15,7 +15,6 @@ import {
 } from "vue";
 
 import { VDataTableServer } from "vuetify/components";
-import axios, { CancelTokenSource } from "axios";
 import { useAsyncAxios } from "@qnx/composables/axios";
 import { objectToQueryString } from "@qnx/composables";
 import { useListRepository } from "../../../composables/list";
@@ -92,7 +91,7 @@ export const VqDataTable = defineComponent({
             { deep: true }
         );
 
-        let cancelToken: CancelTokenSource;
+        let abortController: AbortController | undefined;
         const fetchItems = async ({
             page,
             itemsPerPage,
@@ -103,8 +102,8 @@ export const VqDataTable = defineComponent({
             sortBy: SortByValue[];
         }) => {
             try {
-                cancelToken?.cancel();
-                cancelToken = axios.CancelToken.source();
+                abortController?.abort();
+                abortController = new AbortController();
 
                 loading.value = true;
 
@@ -123,9 +122,9 @@ export const VqDataTable = defineComponent({
                         ""
                     )}`,
                     {
-                        method: props.method
-                    },
-                    { cancelToken }
+                        method: props.method,
+                        signal: abortController.signal
+                    }
                 );
                 loading.value = false;
                 return response.data;

--- a/src/components/Vuetify/VqList/VqList.tsx
+++ b/src/components/Vuetify/VqList/VqList.tsx
@@ -16,7 +16,6 @@ import {
 } from "vue";
 
 import { VList } from "vuetify/components";
-import axios, { CancelTokenSource } from "axios";
 import { objectToQueryString } from "@qnx/composables";
 import { useAsyncAxios } from "@qnx/composables/axios";
 import { useListRepository } from "../../../composables/list";
@@ -111,11 +110,11 @@ export const VqList = defineComponent({
                 .catch(() => {});
         };
 
-        let cancelToken: CancelTokenSource;
+        let abortController: AbortController | undefined;
         const fetchItems = async () => {
             try {
-                cancelToken?.cancel();
-                cancelToken = axios.CancelToken.source();
+                abortController?.abort();
+                abortController = new AbortController();
 
                 loading.value = true;
 
@@ -127,9 +126,9 @@ export const VqList = defineComponent({
                         ""
                     )}`,
                     {
-                        method: "GET"
-                    },
-                    { cancelToken }
+                        method: "GET",
+                        signal: abortController.signal
+                    }
                 );
                 loading.value = false;
                 return response.data;


### PR DESCRIPTION
axios deprecated CancelToken in 0.22 in favor of the standard AbortController/AbortSignal pair. The fetcher in VqList and VqDataTable already pass the cancel mechanism through to axios via config — useAsyncAxios in @qnx/composables forwards args.signal as-is, so we can swap to AbortController without touching the composable lib.

Net effect: same in-flight cancellation behavior on filter/page changes, but no use of deprecated axios API.