### PR TITLE
refactor: tighten types, drop unnecessary ts-ignore / ts-nocheck

### DIFF
--- a/src/components/Basic/SubmitButton.tsx
+++ b/src/components/Basic/SubmitButton.tsx
@@ -31,7 +31,7 @@ export const VqSubmitBtn = defineComponent({
             <>
                 <VBtn
                     loading={loading.value}
-                    /* @ts-ignore */
+                    /* @ts-ignore Vuetify VBtn types omit native button type */
                     type="submit"
                     form={props.form}
                     color="primary"

--- a/src/components/Vuetify/VqDataTable/index.tsx
+++ b/src/components/Vuetify/VqDataTable/index.tsx
@@ -181,9 +181,7 @@ export type ExtractComponentProps<TComponent> = TComponent extends new () => {
     ? P
     : never;
 
-interface GenericProps
-    extends ExtractComponentProps<typeof VqDataTable>,
-        ExtractComponentProps<typeof VqDataTable> {}
+type GenericProps = ExtractComponentProps<typeof VqDataTable>;
 
 interface GenericSlotsProps<TValue> {
     item: TValue;
@@ -240,7 +238,6 @@ export const VqSerialNo = defineComponent({
     setup(props) {
         return () => (
             <>
-                {/* @ts-ignore */}
                 <td>{props.index}</td>
             </>
         );

--- a/src/components/Vuetify/VqForm/VqForm.tsx
+++ b/src/components/Vuetify/VqForm/VqForm.tsx
@@ -105,8 +105,8 @@ export const VqForm = defineComponent({
                     const { eResponse } = await getErrorResponse(response);
                     if (eResponse.value) {
                         const apiResponse = new ApiResponse(eResponse.value);
-                        //@ts-ignore
-                        actions.setErrors(apiResponse.getErrors());
+                        const errors = apiResponse.getErrors();
+                        if (errors) actions.setErrors(errors);
                         emit("submitedError", apiResponse);
                     }
                 })
@@ -131,8 +131,7 @@ export const VqForm = defineComponent({
 
         return () => (
             <>
-                {/* @ts-ignore */}
-                <form novalidate id={props.id} onSubmit={onFinalSubmit} v-slots={slots} {...attrs}>
+                <form novalidate id={props.id} onSubmit={onFinalSubmit} {...attrs}>
                     {slots.default?.()}
                 </form>
             </>
@@ -242,8 +241,8 @@ export const useVqForm = (opts: VqFormOption) => {
                         const { eResponse } = await getErrorResponse(response);
                         if (eResponse.value) {
                             const apiResponse = new ApiResponse(eResponse.value);
-                            //@ts-ignore
-                            actions.setErrors(apiResponse.getErrors());
+                            const errors = apiResponse.getErrors();
+                            if (errors) actions.setErrors(errors);
                             emit("submitedError", apiResponse);
                         }
                     })
@@ -256,8 +255,7 @@ export const useVqForm = (opts: VqFormOption) => {
 
             return () => (
                 <>
-                    {/* @ts-ignore */}
-                    <form novalidate onSubmit={onSubmit} v-slots={slots} {...attrs}>
+                    <form novalidate onSubmit={onSubmit} {...attrs}>
                         {slots.default?.()}
                     </form>
                 </>

--- a/src/components/Vuetify/VqList/VqList.tsx
+++ b/src/components/Vuetify/VqList/VqList.tsx
@@ -91,8 +91,7 @@ export const VqList = defineComponent({
 
         watch(
             () => formFilterData.value,
-            //@ts-ignore
-            (newVal, oldVal) => {
+            (_newVal, oldVal) => {
                 if (oldVal === undefined) return;
                 listOptions.page = 1;
                 loadMore();
@@ -185,9 +184,7 @@ export type ExtractComponentProps<TComponent> = TComponent extends new () => {
     ? P
     : never;
 
-interface GenericProps
-    extends ExtractComponentProps<typeof VqList>,
-        ExtractComponentProps<typeof VqList> {}
+type GenericProps = ExtractComponentProps<typeof VqList>;
 
 interface GenericSlotsProps<TValue> {
     items: TValue[];

--- a/src/components/Vuetify/VqList/VqListLoadMoreBtn.tsx
+++ b/src/components/Vuetify/VqList/VqListLoadMoreBtn.tsx
@@ -1,15 +1,17 @@
-//@ts-nocheck
 import { defineComponent, inject, Ref } from "vue";
 import { VBtn } from "vuetify/components";
+
+interface VqListInjection {
+    loading: Ref<boolean>;
+    finished: Ref<boolean>;
+    tableListId: string;
+    loadMore: () => void;
+}
+
 export const VqListLoadMoreBtn = defineComponent({
     name: "VqListLoadMoreBtn",
-    setup(props, { attrs, slots }) {
-        const vqList = inject<{
-            loading: Ref<boolean>;
-            finished: Ref<boolean>;
-            tableListId: string;
-            loadMore: () => void;
-        }>("vqList");
+    setup(_props, { attrs, slots }) {
+        const vqList = inject<VqListInjection>("vqList");
 
         return () => (
             <>
@@ -18,6 +20,7 @@ export const VqListLoadMoreBtn = defineComponent({
                         loading={vqList?.loading.value}
                         disabled={vqList?.loading.value}
                         color="primary"
+                        /* @ts-ignore Vuetify VBtn types omit onClick */
                         onClick={vqList?.loadMore}
                         v-slots={slots}
                         {...attrs}

--- a/src/components/Vuetify/VqList/VqTableFilter.tsx
+++ b/src/components/Vuetify/VqList/VqTableFilter.tsx
@@ -23,13 +23,8 @@ export const VqTableFilter = defineComponent({
 
         return () => (
             <>
-                {/*  @ts-ignore */}
-                <VForm
-                    //@ts-ignore
-                    id={filterId.value}
-                    {...attrs}
-                >
-                    {/*  @ts-ignore */}
+                {/* @ts-ignore vee-validate VForm types omit id */}
+                <VForm id={filterId.value} {...attrs}>
                     <VqTableFilterHandler id={filterId.value} v-slots={slots}>
                         <>{slots.default?.()}</>
                     </VqTableFilterHandler>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as components from "./components";
-import type { App } from "vue";
+import type { App, Component } from "vue";
 
 //Export components
 export * from "./components";
@@ -13,9 +13,11 @@ export { useVqForm } from "./components/Vuetify/VqForm/VqForm";
 //Instance of main components of vq vuetify
 export default {
     install: (app: App) => {
-        for (const key in components) {
-            //@ts-ignore
-            app.component(key, components[key]);
+        const all = components as Record<string, Component>;
+        for (const key of Object.keys(all)) {
+            // The barrel re-exports composables (useVqForm) and helpers
+            // (collectVqHeaders) too — only auto-register actual components.
+            if (key.startsWith("Vq")) app.component(key, all[key]);
         }
     }
 };

--- a/src/integrations.ts
+++ b/src/integrations.ts
@@ -1,16 +1,16 @@
-import * as components from './components/integrations'
-export { setConfig } from './components/Tinymce/config'
+import * as components from "./components/integrations";
+export { setConfig } from "./components/Tinymce/config";
 
-import type { App } from 'vue'
+import type { App, Component } from "vue";
 
-export * from './components/integrations'
+export * from "./components/integrations";
 
 //Instance of additional components of vq vuetify
 export default {
     install: (app: App) => {
-        for (const key in components) {
-            //@ts-ignore
-            app.component(key, components[key])
+        const all = components as Record<string, Component>;
+        for (const key of Object.keys(all)) {
+            if (key.startsWith("Vq")) app.component(key, all[key]);
         }
     }
-}
+};


### PR DESCRIPTION
Down from 18 suppressions to 8 — every remaining one is annotated with the upstream reason (vee-validate VForm id gap, Vuetify VBtn type/onClick gaps, TinyMCE editor JSX quirks).

- src/index.ts and src/integrations.ts: type the install loop properly with `Component`, drop the //@ts-ignore. Filter to keys starting with "Vq" so composables (useVqForm) and helpers (collectVqHeaders) that also live on the barrel are not registered as Vue components.
- VqListLoadMoreBtn: replace whole-file //@ts-nocheck with one targeted comment on the onClick line. Underscore-prefix the unused `props` arg.
- VqForm setErrors: ApiResponse.getErrors() returns `Record<string, string[]>
  | undefined`, which vee-validate's setErrors already accepts — handle the undefined branch and drop the suppression in both the component and useVqForm versions.
- VqForm <form>: drop unnecessary v-slots={slots} on the native form element (children render via slots.default?.()), removes the suppression.
- VqList watch: rename unused newVal -> _newVal, drop the suppression.
- VqTableFilter: VqTableFilterHandler typing was fine — only the VForm id prop needs suppression. Two suppressions removed.
- VqDataTable VqSerialNo: <td> JSX typed fine without suppression.
- VqList / VqDataTable: collapse `interface GenericProps extends X, X {}` duplicate-extends to `type GenericProps = X` (the second extension was redundant — same type listed twice).