### PR TITLE
feat(VqSubmitBtn): support custom label via prop or default slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ These components must be used inside a `VqForm` or `useVqForm` wrapper. They aut
 | `VqOtpInput` | OTP (one-time password) input bound to form state. |
 | `VqFileInput` | File input bound to form state. |
 | `VqFileUpload` | File upload input with upload handling. |
-| `VqSubmitBtn` | Submit button that reflects form busy/loading state. |
+| `VqSubmitBtn` | Submit button that reflects form busy/loading state. Pass a custom label via the `text` prop or the default slot. |
 
 #### `VqForm` Props
 

--- a/src/components/Basic/SubmitButton.tsx
+++ b/src/components/Basic/SubmitButton.tsx
@@ -1,4 +1,4 @@
-import { Ref, computed, defineComponent, inject, readonly, ref, toRef } from "vue";
+import { Ref, computed, defineComponent, inject, PropType } from "vue";
 import { useFormStore } from "../../store/reactivity/form";
 import { VBtn } from "vuetify/components";
 
@@ -8,18 +8,14 @@ export const VqSubmitBtn = defineComponent({
         form: {
             type: String,
             default: undefined
+        },
+        text: {
+            type: String as PropType<string>,
+            default: undefined
         }
     },
-    setup(props, { attrs }) {
+    setup(props, { attrs, slots }) {
         const formStore = useFormStore();
-
-        //const internalformId = inject<Readonly<Ref<string | undefined>>>("formId");
-        //  const externalformId = toRef(props, "form");
-        // const formId = computed(() => internalformId?.value ?? externalformId?.value);
-
-        // const loading = computed(
-        //     () => (formId.value && formStore.forms[formId.value]?.busy) ?? false
-        // );
 
         const formId = inject<Readonly<Ref<string | undefined>>>("formId");
 
@@ -31,13 +27,13 @@ export const VqSubmitBtn = defineComponent({
             <>
                 <VBtn
                     loading={loading.value}
-                    /* @ts-ignore */
+                    /* @ts-ignore Vuetify VBtn types omit native button type */
                     type="submit"
                     form={props.form}
                     color="primary"
                     {...attrs}
                 >
-                    Submit
+                    {slots.default ? slots.default() : (props.text ?? "Submit")}
                 </VBtn>
             </>
         );


### PR DESCRIPTION
Hard-coded "Submit" was the only option for the button text. Add a `text` prop and pass-through for the default slot so the caller can override without re-styling. Resolution order:

  default slot > text prop > "Submit" fallback

Existing usage (no prop, no slot) still renders "Submit" — backwards compatible.