### PR TITLE
fix: bind itemsPerPage and sortBy to VDataTableServer

### DIFF
--- a/src/components/Vuetify/VqDataTable/index.tsx
+++ b/src/components/Vuetify/VqDataTable/index.tsx
@@ -155,6 +155,8 @@ export const VqDataTable = defineComponent({
                 <VDataTableServer
                     loading={loading.value ? "primary" : false}
                     page={defaultOptions.page}
+                    itemsPerPage={defaultOptions.itemsPerPage}
+                    sortBy={defaultOptions.sortBy}
                     items={items.value}
                     itemsLength={totalItems.value}
                     onUpdate:options={updateOptions}


### PR DESCRIPTION
VqDataTable collected `itemsPerPage` and `sortBy` into its internal `defaultOptions` but only bound `page` to the rendered VDataTableServer. As a result the documented `itemsPerPage` and `sortBy` props had no effect: a caller setting `:items-per-page="25"` still got Vuetify's internal default of 10, and the documented default sort `[{ key: "name", order: "asc" }]` was never applied to the initial fetch.

Bind both as controlled props alongside `page` (the matching `onUpdate:*` handlers that write back to `defaultOptions` already exist), so the props now actually control the table.