### PR TITLE
test: add coverage for components, composables and stores

### DIFF
--- a/src/components/Basic/__tests__/MessageQueue.spec.ts
+++ b/src/components/Basic/__tests__/MessageQueue.spec.ts
@@ -1,0 +1,108 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+
+// These SFCs use a plain (untyped) <script>, so vue-tsc types the default
+// export as implicit `any`; there's no `*.vue` shim in this project (it is
+// intentionally commented out in env.d.ts). Suppress the import-level TS7016.
+// @ts-ignore -- untyped .vue SFC default import
+import VSnackbarQueue from "../VSnackbarQueue.vue";
+// @ts-ignore -- untyped .vue SFC default import
+import MessageQueue from "../MessageQueue.vue";
+import { useMessageStore } from "../../../store/reactivity/message";
+
+// VSnackbarQueue renders one VSnackbar per queued message, showing only the
+// head of the queue (model-value === first item). MessageQueue is the thin
+// store binding that feeds it the message store's items and wires the remove
+// action back to removeMessage. Snackbar content teleports to document.body.
+describe("VSnackbarQueue + MessageQueue", () => {
+    // These are .vue SFCs that reference kebab-case <v-snackbar>/<v-btn> in
+    // their templates, so the Vuetify components must be globally registered
+    // (the TSX components import them directly and don't need this).
+    const vuetify = createVuetify({ components });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    describe("VSnackbarQueue", () => {
+        const mountQueue = (items: unknown[]) =>
+            mount(VSnackbarQueue, {
+                props: { items },
+                global: { plugins: [vuetify] }
+            });
+
+        it("shows the message of the active (first) item", async () => {
+            mountQueue([{ id: 1, message: "Saved!", color: "success" }]);
+            await flushPromises();
+            expect(document.body.textContent).toContain("Saved!");
+        });
+
+        it("labels the action 'Close' for a single item", async () => {
+            mountQueue([{ id: 1, message: "only", color: "success" }]);
+            await flushPromises();
+            expect(document.body.textContent).toContain("Close");
+        });
+
+        it("labels the action 'Next(n-1)' when more remain in the queue", async () => {
+            mountQueue([
+                { id: 1, message: "first", color: "success" },
+                { id: 2, message: "second", color: "error" }
+            ]);
+            await flushPromises();
+            expect(document.body.textContent).toContain("Next(1)");
+        });
+
+        it("emits `remove` with the item id when the action is clicked", async () => {
+            const wrapper = mountQueue([{ id: 42, message: "bye", color: "success" }]);
+            await flushPromises();
+
+            const btn = Array.from(
+                document.body.querySelectorAll<HTMLElement>(".v-btn")
+            ).find((b) => /Close|Next/.test(b.textContent ?? ""));
+            expect(btn).toBeTruthy();
+
+            btn!.click();
+            await flushPromises();
+
+            expect(wrapper.emitted("remove")?.[0]).toEqual([42]);
+        });
+    });
+
+    describe("MessageQueue", () => {
+        let pinia: Pinia;
+
+        beforeEach(() => {
+            pinia = createPinia();
+            setActivePinia(pinia);
+        });
+
+        it("renders a message pushed onto the store", async () => {
+            mount(MessageQueue, { global: { plugins: [vuetify, pinia] } });
+            const store = useMessageStore();
+            store.addMessage({ message: "Hello there", color: "success" });
+            await flushPromises();
+
+            expect(document.body.textContent).toContain("Hello there");
+        });
+
+        it("removes the message from the store when the action is clicked", async () => {
+            mount(MessageQueue, { global: { plugins: [vuetify, pinia] } });
+            const store = useMessageStore();
+            store.addMessage({ message: "dismiss me", color: "success" });
+            await flushPromises();
+
+            const btn = Array.from(
+                document.body.querySelectorAll<HTMLElement>(".v-btn")
+            ).find((b) => /Close|Next/.test(b.textContent ?? ""));
+            expect(btn).toBeTruthy();
+
+            btn!.click();
+            await flushPromises();
+
+            expect(store.items).toHaveLength(0);
+        });
+    });
+});

--- a/src/components/Basic/__tests__/SubmitButton.spec.tsx
+++ b/src/components/Basic/__tests__/SubmitButton.spec.tsx
@@ -1,0 +1,66 @@
+import { VqSubmitBtn } from "../SubmitButton";
+import { useFormStore } from "../../../store/reactivity/form";
+
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createVuetify } from "vuetify";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+import { ref } from "vue";
+
+describe("VqSubmitBtn", () => {
+    const vuetify = createVuetify();
+    let pinia: Pinia;
+
+    beforeEach(() => {
+        pinia = createPinia();
+        setActivePinia(pinia);
+    });
+
+    const mountBtn = (options: Record<string, any> = {}) =>
+        mount(VqSubmitBtn, {
+            global: { plugins: [vuetify, pinia], ...(options.global ?? {}) },
+            ...options
+        });
+
+    it("falls back to the localized 'Submit' label", () => {
+        const wrapper = mountBtn();
+        expect(wrapper.text()).toContain("Submit");
+    });
+
+    it("renders the `text` prop when provided", () => {
+        const wrapper = mountBtn({ props: { text: "Save changes" } });
+        expect(wrapper.text()).toContain("Save changes");
+        expect(wrapper.text()).not.toContain("Submit");
+    });
+
+    it("prefers the default slot over the text prop", () => {
+        const wrapper = mountBtn({
+            props: { text: "Save changes" },
+            slots: { default: () => "Go!" }
+        });
+        expect(wrapper.text()).toContain("Go!");
+        expect(wrapper.text()).not.toContain("Save changes");
+    });
+
+    it("is not loading when no form id is injected", () => {
+        const wrapper = mountBtn();
+        expect(wrapper.find(".v-btn").classes()).not.toContain("v-btn--loading");
+    });
+
+    it("shows the loading state when the injected form is busy", () => {
+        const store = useFormStore();
+        store.addForm("create-user");
+        store.changeBusy("create-user", true);
+
+        const wrapper = mountBtn({
+            global: { plugins: [vuetify, pinia], provide: { formId: ref("create-user") } }
+        });
+
+        expect(wrapper.find(".v-btn").classes()).toContain("v-btn--loading");
+    });
+
+    it("renders a submit-type button", () => {
+        const wrapper = mountBtn();
+        expect(wrapper.find("button").attributes("type")).toBe("submit");
+    });
+});

--- a/src/components/Tinymce/__tests__/VqTextEditor.spec.tsx
+++ b/src/components/Tinymce/__tests__/VqTextEditor.spec.tsx
@@ -1,0 +1,44 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent, h } from "vue";
+
+// The real TinyMCE editor lazy-loads a remote script and a full DOM editor,
+// which can't run under jsdom. Stub it with a minimal model-value <-> input
+// bridge so we can verify VqTextEditor's vee-validate wiring in isolation.
+vi.mock("@tinymce/tinymce-vue", () => ({
+    default: defineComponent({
+        name: "TinyEditorStub",
+        props: { modelValue: { type: String, default: "" } },
+        emits: ["update:modelValue"],
+        setup(props, { emit }) {
+            return () =>
+                h("textarea", {
+                    class: "tiny-stub",
+                    value: props.modelValue,
+                    onInput: (e: Event) =>
+                        emit("update:modelValue", (e.target as HTMLTextAreaElement).value)
+                });
+        }
+    })
+}));
+
+import { VqTextEditor } from "../index";
+
+describe("VqTextEditor", () => {
+    const mountEditor = (props: Record<string, unknown> = {}) =>
+        mount(VqTextEditor, { props: { name: "body", ...props } });
+
+    it("mounts and renders the (stubbed) editor", () => {
+        const wrapper = mountEditor();
+        expect(wrapper.find(".tiny-stub").exists()).toBe(true);
+    });
+
+    it("mirrors editor input into the bound vee-validate field value", async () => {
+        const wrapper = mountEditor();
+
+        await wrapper.find("textarea").setValue("<p>hello</p>");
+
+        // value.value flows back down as model-value -> the stub's textarea value
+        expect(wrapper.find("textarea").element.value).toBe("<p>hello</p>");
+    });
+});

--- a/src/components/Vuetify/VqAutocomplete/__tests__/VqAutocomplete.spec.tsx
+++ b/src/components/Vuetify/VqAutocomplete/__tests__/VqAutocomplete.spec.tsx
@@ -1,0 +1,69 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import { VAutocomplete } from "vuetify/components";
+
+vi.mock("@qnx/composables/axios", () => ({
+    useAsyncAxios: vi.fn()
+}));
+
+import { useAsyncAxios } from "@qnx/composables/axios";
+import { VqAutocomplete } from "../index";
+
+// When given an `action`, VqAutocomplete fetches its option list on mount via
+// useAsyncAxios and feeds `res.data.data` into the underlying VAutocomplete.
+describe("VqAutocomplete (remote items)", () => {
+    const vuetify = createVuetify();
+
+    beforeEach(() => {
+        vi.mocked(useAsyncAxios).mockReset();
+    });
+
+    const mountAutocomplete = (props: Record<string, unknown>) =>
+        mount(VqAutocomplete, {
+            props: { name: "country", ...props },
+            global: { plugins: [vuetify] }
+        });
+
+    it("fetches options from `action` on mount and passes them to VAutocomplete", async () => {
+        const options = [
+            { title: "Alpha", value: 1 },
+            { title: "Beta", value: 2 }
+        ];
+        vi.mocked(useAsyncAxios).mockResolvedValue({ data: { data: options } } as never);
+
+        const wrapper = mountAutocomplete({ action: "countries" });
+        await flushPromises();
+
+        expect(useAsyncAxios).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(useAsyncAxios).mock.calls[0][0]).toBe("countries");
+
+        const inner = wrapper.findComponent(VAutocomplete);
+        expect(inner.props("items")).toEqual(options);
+        expect(inner.props("loading")).toBe(false);
+    });
+
+    it("does not fetch when no `action` is provided", async () => {
+        const wrapper = mountAutocomplete({ items: [{ title: "Static", value: 9 }] });
+        await flushPromises();
+
+        expect(useAsyncAxios).not.toHaveBeenCalled();
+        expect(wrapper.findComponent(VAutocomplete).props("items")).toEqual([
+            { title: "Static", value: 9 }
+        ]);
+    });
+
+    it("logs and recovers when the fetch rejects", async () => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        vi.mocked(useAsyncAxios).mockRejectedValue(new Error("network down") as never);
+
+        const wrapper = mountAutocomplete({ action: "countries" });
+        await flushPromises();
+
+        expect(errorSpy).toHaveBeenCalledWith("network down");
+        // loading is cleared in finally even on failure
+        expect(wrapper.findComponent(VAutocomplete).props("loading")).toBe(false);
+
+        errorSpy.mockRestore();
+    });
+});

--- a/src/components/Vuetify/VqDataTable/__tests__/VqDataTable.spec.tsx
+++ b/src/components/Vuetify/VqDataTable/__tests__/VqDataTable.spec.tsx
@@ -1,0 +1,73 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+
+vi.mock("@qnx/composables/axios", () => ({
+    useAsyncAxios: vi.fn()
+}));
+
+import { useAsyncAxios } from "@qnx/composables/axios";
+import { VqDataTable } from "../index";
+
+// VDataTableServer emits `update:options` on mount, which drives the initial
+// fetch through VqDataTable.fetchItems. We mock the async HTTP layer so we can
+// assert (a) that a fetch happens and (b) that the documented itemsPerPage /
+// sortBy props are honoured (the binding fix shipped in PR #14): the values we
+// pass must surface in the request query string.
+const page = (items: unknown[], total: number) => ({ data: { data: items, total } });
+
+describe("VqDataTable", () => {
+    const vuetify = createVuetify();
+    let pinia: Pinia;
+
+    beforeEach(() => {
+        pinia = createPinia();
+        setActivePinia(pinia);
+        vi.mocked(useAsyncAxios).mockReset();
+    });
+
+    const mountTable = (props: Record<string, unknown> = {}) =>
+        mount(VqDataTable, {
+            props: { id: "users", action: "users", ...props },
+            global: { plugins: [vuetify, pinia] }
+        });
+
+    it("renders a VDataTableServer and fetches the first page on mount", async () => {
+        vi.mocked(useAsyncAxios).mockResolvedValue(page([{ id: 1 }, { id: 2 }], 5) as never);
+
+        const wrapper = mountTable();
+        await flushPromises();
+
+        expect(wrapper.find(".v-data-table").exists()).toBe(true);
+        expect(useAsyncAxios).toHaveBeenCalled();
+        expect(vi.mocked(useAsyncAxios).mock.calls[0][0]).toContain("users?");
+
+        wrapper.unmount();
+    });
+
+    it("honours the itemsPerPage prop in the fetch query (binding fix)", async () => {
+        vi.mocked(useAsyncAxios).mockResolvedValue(page([], 0) as never);
+
+        const wrapper = mountTable({ itemsPerPage: 25 });
+        await flushPromises();
+
+        const url = String(vi.mocked(useAsyncAxios).mock.calls[0][0]);
+        expect(url).toContain("itemsPerPage=25");
+        expect(url).toContain("page=1");
+
+        wrapper.unmount();
+    });
+
+    it("forwards the configured HTTP method to useAsyncAxios", async () => {
+        vi.mocked(useAsyncAxios).mockResolvedValue(page([], 0) as never);
+
+        const wrapper = mountTable({ method: "POST" });
+        await flushPromises();
+
+        const config = vi.mocked(useAsyncAxios).mock.calls[0][1];
+        expect(config).toMatchObject({ method: "POST" });
+
+        wrapper.unmount();
+    });
+});

--- a/src/components/Vuetify/VqForm/__tests__/VqForm.spec.tsx
+++ b/src/components/Vuetify/VqForm/__tests__/VqForm.spec.tsx
@@ -1,0 +1,91 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+import { defineComponent, inject, type Ref } from "vue";
+
+// Mock the async HTTP layer so submission is deterministic and offline.
+vi.mock("@qnx/composables/axios", () => ({
+    useAsyncAxios: vi.fn(),
+    useErrorResponse: vi.fn(() => ({ getErrorResponse: vi.fn() }))
+}));
+
+import { useAsyncAxios } from "@qnx/composables/axios";
+import { VqForm } from "../VqForm";
+import { VqTextField } from "../../VqTextField";
+import { useFormStore } from "../../../../store/reactivity/form";
+
+const FormIdProbe = defineComponent({
+    setup() {
+        const formId = inject<Readonly<Ref<string | undefined>>>("formId");
+        return () => <span class="probe">{formId?.value}</span>;
+    }
+});
+
+describe("VqForm", () => {
+    const vuetify = createVuetify();
+    let pinia: Pinia;
+
+    beforeEach(() => {
+        pinia = createPinia();
+        setActivePinia(pinia);
+        vi.mocked(useAsyncAxios).mockReset();
+    });
+
+    const mountForm = (props: Record<string, unknown>, slots: Record<string, any> = {}) =>
+        mount(VqForm, {
+            props: { id: "create-user", action: "users/create", ...props },
+            slots,
+            global: { plugins: [vuetify, pinia] }
+        });
+
+    it("renders a <form> carrying the id and the default slot", () => {
+        const wrapper = mountForm({}, { default: () => <button class="child">Go</button> });
+        const form = wrapper.find("form");
+        expect(form.exists()).toBe(true);
+        expect(form.attributes("id")).toBe("create-user");
+        expect(wrapper.find(".child").exists()).toBe(true);
+    });
+
+    it("registers the form in the store on mount and provides its id", () => {
+        const wrapper = mountForm({}, { default: () => <FormIdProbe /> });
+        const store = useFormStore();
+        expect(store.forms["create-user"]).toEqual({ busy: false });
+        expect(wrapper.find(".probe").text()).toBe("create-user");
+    });
+
+    it("posts via useAsyncAxios and calls the success handler with the response", async () => {
+        const response = { data: { id: 1 }, ok: true };
+        vi.mocked(useAsyncAxios).mockResolvedValue(response as never);
+        const successResponseHandler = vi.fn();
+
+        const wrapper = mountForm(
+            { method: "POST", initialValues: { email: "a@b.c" }, successResponseHandler },
+            { default: () => <VqTextField name="email" /> }
+        );
+
+        await wrapper.find("form").trigger("submit");
+        await flushPromises();
+
+        expect(useAsyncAxios).toHaveBeenCalledTimes(1);
+        const [calledAction, calledConfig] = vi.mocked(useAsyncAxios).mock.calls[0];
+        expect(calledAction).toBe("users/create");
+        expect(calledConfig).toMatchObject({ method: "POST", data: { email: "a@b.c" } });
+        expect(successResponseHandler).toHaveBeenCalledTimes(1);
+        expect(successResponseHandler.mock.calls[0][0]).toBe(response);
+    });
+
+    it("routes rejections to the error handler", async () => {
+        const err = new Error("boom");
+        vi.mocked(useAsyncAxios).mockRejectedValue(err as never);
+        const errorResponseHandler = vi.fn();
+
+        const wrapper = mountForm({ errorResponseHandler });
+
+        await wrapper.find("form").trigger("submit");
+        await flushPromises();
+
+        expect(errorResponseHandler).toHaveBeenCalledTimes(1);
+        expect(errorResponseHandler.mock.calls[0][0]).toBe(err);
+    });
+});

--- a/src/components/Vuetify/VqList/__tests__/VqList.spec.tsx
+++ b/src/components/Vuetify/VqList/__tests__/VqList.spec.tsx
@@ -1,0 +1,82 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+
+vi.mock("@qnx/composables/axios", () => ({
+    useAsyncAxios: vi.fn()
+}));
+
+import { useAsyncAxios } from "@qnx/composables/axios";
+import { VqList } from "../VqList";
+
+const page = (items: unknown[], total: number) => ({ data: { data: items, total } });
+
+describe("VqList", () => {
+    const vuetify = createVuetify();
+    let pinia: Pinia;
+
+    beforeEach(() => {
+        pinia = createPinia();
+        setActivePinia(pinia);
+        vi.mocked(useAsyncAxios).mockReset();
+    });
+
+    const mountList = (id: string, pageSize = 2) =>
+        mount(VqList, {
+            props: { id, action: "posts", pageSize },
+            slots: {
+                default: (arg: any) => (
+                    <div>
+                        <span class="count">{arg.items.length}</span>
+                        <span class="finished">{String(arg.finished)}</span>
+                        <button class="more" onClick={arg.loadMore}>
+                            more
+                        </button>
+                    </div>
+                )
+            },
+            global: { plugins: [vuetify, pinia] }
+        });
+
+    it("fetches the first page on mount and exposes items via the default slot", async () => {
+        vi.mocked(useAsyncAxios).mockResolvedValueOnce(page([{ id: 1 }, { id: 2 }], 5) as never);
+
+        const wrapper = mountList("a");
+        await flushPromises();
+
+        expect(useAsyncAxios).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(useAsyncAxios).mock.calls[0][0]).toContain("posts?");
+        expect(wrapper.find(".count").text()).toBe("2");
+        expect(wrapper.find(".finished").text()).toBe("false");
+
+        wrapper.unmount();
+    });
+
+    it("marks the list finished once page_size * page covers the total", async () => {
+        vi.mocked(useAsyncAxios).mockResolvedValueOnce(page([{ id: 1 }, { id: 2 }], 2) as never);
+
+        const wrapper = mountList("b");
+        await flushPromises();
+
+        expect(wrapper.find(".finished").text()).toBe("true");
+        wrapper.unmount();
+    });
+
+    it("appends the next page when loadMore is invoked", async () => {
+        vi.mocked(useAsyncAxios)
+            .mockResolvedValueOnce(page([{ id: 1 }, { id: 2 }], 5) as never)
+            .mockResolvedValueOnce(page([{ id: 3 }, { id: 4 }], 5) as never);
+
+        const wrapper = mountList("c");
+        await flushPromises();
+        expect(wrapper.find(".count").text()).toBe("2");
+
+        await wrapper.find(".more").trigger("click");
+        await flushPromises();
+
+        expect(useAsyncAxios).toHaveBeenCalledTimes(2);
+        expect(wrapper.find(".count").text()).toBe("4");
+        wrapper.unmount();
+    });
+});

--- a/src/components/Vuetify/VqList/__tests__/VqListLoadMoreBtn.spec.tsx
+++ b/src/components/Vuetify/VqList/__tests__/VqListLoadMoreBtn.spec.tsx
@@ -1,0 +1,61 @@
+import { VqListLoadMoreBtn } from "../VqListLoadMoreBtn";
+
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import { ref } from "vue";
+
+describe("VqListLoadMoreBtn", () => {
+    const vuetify = createVuetify();
+
+    const mountBtn = (injection: Record<string, any>) =>
+        mount(VqListLoadMoreBtn, {
+            global: { plugins: [vuetify], provide: { vqList: injection } }
+        });
+
+    it("renders the localized 'Load More' button when the list is not finished", () => {
+        const wrapper = mountBtn({
+            loading: ref(false),
+            finished: ref(false),
+            tableListId: "users",
+            loadMore: vi.fn()
+        });
+        expect(wrapper.find(".v-btn").exists()).toBe(true);
+        expect(wrapper.text()).toContain("Load More");
+    });
+
+    it("calls loadMore from the injection when clicked", async () => {
+        const loadMore = vi.fn();
+        const wrapper = mountBtn({
+            loading: ref(false),
+            finished: ref(false),
+            tableListId: "users",
+            loadMore
+        });
+
+        await wrapper.find(".v-btn").trigger("click");
+        expect(loadMore).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the button once the list is finished", () => {
+        const wrapper = mountBtn({
+            loading: ref(false),
+            finished: ref(true),
+            tableListId: "users",
+            loadMore: vi.fn()
+        });
+        expect(wrapper.find(".v-btn").exists()).toBe(false);
+    });
+
+    it("reflects the loading state as a disabled, loading button", () => {
+        const wrapper = mountBtn({
+            loading: ref(true),
+            finished: ref(false),
+            tableListId: "users",
+            loadMore: vi.fn()
+        });
+        const classes = wrapper.find(".v-btn").classes();
+        expect(classes).toContain("v-btn--loading");
+        expect(classes).toContain("v-btn--disabled");
+    });
+});

--- a/src/components/Vuetify/VqList/__tests__/VqTableFilter.spec.tsx
+++ b/src/components/Vuetify/VqList/__tests__/VqTableFilter.spec.tsx
@@ -1,0 +1,58 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createVuetify } from "vuetify";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+
+import { VqTableFilter } from "../VqTableFilter";
+import { VqTextField } from "../../VqTextField";
+import { useFormFilterStore } from "../../../../store/reactivity/formFiler";
+
+// VqTableFilter wraps its slot in a vee-validate <Form> + VqTableFilterHandler.
+// The handler mirrors the form's values into the form-filter store under
+// `${id}_filter`, which is the contract VqDataTable / VqList rely on.
+describe("VqTableFilter + VqTableFilterHandler", () => {
+    const vuetify = createVuetify();
+    let pinia: Pinia;
+
+    beforeEach(() => {
+        pinia = createPinia();
+        setActivePinia(pinia);
+    });
+
+    const mountFilter = () =>
+        mount(VqTableFilter, {
+            props: { id: "users" },
+            slots: { default: () => <VqTextField name="search" /> },
+            global: { plugins: [vuetify, pinia] }
+        });
+
+    it("registers a `${id}_filter` entry in the store on mount", async () => {
+        mountFilter();
+        await flushPromises();
+
+        const store = useFormFilterStore();
+        expect(store.forms["users_filter"]).toBeDefined();
+        expect(store.forms["users_filter"].values).toHaveProperty("search");
+    });
+
+    it("mirrors field changes into the filter store's values", async () => {
+        const wrapper = mountFilter();
+        await flushPromises();
+
+        await wrapper.find("input").setValue("ann");
+        await flushPromises();
+
+        const store = useFormFilterStore();
+        expect(store.forms["users_filter"].values.search).toBe("ann");
+    });
+
+    it("removes the filter entry when unmounted", async () => {
+        const wrapper = mountFilter();
+        await flushPromises();
+        const store = useFormFilterStore();
+        expect(store.forms["users_filter"]).toBeDefined();
+
+        wrapper.unmount();
+        expect(store.forms["users_filter"]).toBeUndefined();
+    });
+});

--- a/src/components/Vuetify/__tests__/VqDatatableItemAction.spec.tsx
+++ b/src/components/Vuetify/__tests__/VqDatatableItemAction.spec.tsx
@@ -1,0 +1,82 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVuetify } from "vuetify";
+import { createPinia, setActivePinia, type Pinia } from "pinia";
+
+// Mock only the async HTTP subpath. `@qnx/composables` (ApiResponse, used by
+// the confirm handler) stays real.
+vi.mock("@qnx/composables/axios", () => ({
+    useAsyncAxios: vi.fn()
+}));
+
+import { useAsyncAxios } from "@qnx/composables/axios";
+import { VqDatatableItemAction } from "../VqDatatableItemAction";
+
+// The row-action button opens a teleported confirmation dialog; confirming it
+// issues `${action}/${itemId}` via useAsyncAxios and (on success) reloads the
+// owning filter + flashes a success message.
+describe("VqDatatableItemAction", () => {
+    const vuetify = createVuetify();
+    let pinia: Pinia;
+
+    beforeAll(() => {
+        // The message singleton captures the active store on first construction,
+        // so keep one stable pinia for the whole file.
+        pinia = createPinia();
+        setActivePinia(pinia);
+    });
+
+    beforeEach(() => {
+        setActivePinia(pinia);
+        vi.mocked(useAsyncAxios).mockReset();
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    const mountAction = (props: Record<string, unknown> = {}) =>
+        mount(VqDatatableItemAction, {
+            props: { id: "users", action: "users/delete", itemId: "7", ...props },
+            global: { plugins: [vuetify, pinia] }
+        });
+
+    it("renders the row-action trigger button", () => {
+        const wrapper = mountAction();
+        expect(wrapper.find(".v-btn").exists()).toBe(true);
+        wrapper.unmount();
+    });
+
+    it("opens the confirmation dialog when the trigger is clicked", async () => {
+        const wrapper = mountAction();
+        await wrapper.find(".v-btn").trigger("click");
+        await flushPromises();
+
+        // VDialog teleports its content to the overlay container in document.body.
+        expect(document.body.textContent).toContain("Confirmation");
+        expect(document.body.textContent).toContain("Confirm");
+        wrapper.unmount();
+    });
+
+    it("requests `${action}/${itemId}` with the configured method on confirm", async () => {
+        vi.mocked(useAsyncAxios).mockResolvedValue({ data: { message: "Deleted" } } as never);
+
+        const wrapper = mountAction({ method: "DELETE" });
+        await wrapper.find(".v-btn").trigger("click");
+        await flushPromises();
+
+        const confirmBtn = Array.from(
+            document.body.querySelectorAll<HTMLElement>(".v-btn")
+        ).find((b) => b.textContent?.trim() === "Confirm");
+        expect(confirmBtn).toBeTruthy();
+
+        confirmBtn!.click();
+        await flushPromises();
+
+        expect(useAsyncAxios).toHaveBeenCalledTimes(1);
+        const [calledAction, config] = vi.mocked(useAsyncAxios).mock.calls[0];
+        expect(calledAction).toBe("users/delete/7");
+        expect(config).toMatchObject({ method: "DELETE" });
+        wrapper.unmount();
+    });
+});

--- a/src/components/Vuetify/__tests__/fieldWrappers.spec.tsx
+++ b/src/components/Vuetify/__tests__/fieldWrappers.spec.tsx
@@ -1,0 +1,68 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { createVuetify } from "vuetify";
+
+import { VqCheckbox } from "../VqCheckbox";
+import { VqAutocomplete } from "../VqAutocomplete";
+import { VqColorPicker } from "../VqColorPicker";
+import { VqDatePicker } from "../VqDatePicker";
+import { VqTimePicker } from "../VqTimePicker";
+import { VqOtpInput } from "../VqOtpInput";
+import { VqFileInput } from "../VqFileInput";
+import { VqFileUpload } from "../VqFileUpload";
+
+// Smoke coverage for the vee-validate field wrappers: each must mount with
+// just the `name` prop (useField works standalone) and render its underlying
+// Vuetify control without throwing. These guard against the broken-import /
+// bad-render-shape class of regressions.
+describe("vee-validate field wrappers", () => {
+    const vuetify = createVuetify();
+
+    const mountField = (component: any, props: Record<string, unknown> = {}) =>
+        mount(component, {
+            props: { name: "field", ...props },
+            global: { plugins: [vuetify] }
+        });
+
+    it("VqCheckbox renders a Vuetify checkbox", () => {
+        const wrapper = mountField(VqCheckbox);
+        expect(wrapper.find(".v-checkbox").exists()).toBe(true);
+        expect(wrapper.find("input").exists()).toBe(true);
+    });
+
+    it("VqAutocomplete renders a Vuetify autocomplete (no action -> no fetch)", () => {
+        const wrapper = mountField(VqAutocomplete);
+        expect(wrapper.find(".v-autocomplete").exists()).toBe(true);
+    });
+
+    it("VqColorPicker renders its text-field activator", () => {
+        const wrapper = mountField(VqColorPicker, { label: "Colour" });
+        expect(wrapper.find(".v-text-field").exists()).toBe(true);
+    });
+
+    it("VqDatePicker renders its text-field activator", () => {
+        const wrapper = mountField(VqDatePicker, { label: "Date" });
+        expect(wrapper.find(".v-text-field").exists()).toBe(true);
+    });
+
+    it("VqTimePicker renders its text-field activator", () => {
+        const wrapper = mountField(VqTimePicker, { label: "Time" });
+        expect(wrapper.find(".v-text-field").exists()).toBe(true);
+    });
+
+    it("VqOtpInput renders a Vuetify OTP input", () => {
+        const wrapper = mountField(VqOtpInput);
+        expect(wrapper.find(".v-otp-input").exists()).toBe(true);
+    });
+
+    it("VqFileInput renders a Vuetify file input", () => {
+        const wrapper = mountField(VqFileInput);
+        expect(wrapper.find(".v-file-input").exists()).toBe(true);
+        expect(wrapper.find("input[type='file']").exists()).toBe(true);
+    });
+
+    it("VqFileUpload renders a Vuetify file upload", () => {
+        const wrapper = mountField(VqFileUpload);
+        expect(wrapper.find(".v-file-upload").exists()).toBe(true);
+    });
+});

--- a/src/composables/form/__tests__/index.spec.ts
+++ b/src/composables/form/__tests__/index.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useFormFilterRepository } from "../index";
+import { useFormFilterStore } from "../../../store/reactivity/formFiler";
+
+describe("useFormFilterRepository", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("reload() flips reloadRequired on the matching filter form", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", {});
+
+        useFormFilterRepository("users").reload();
+
+        expect(store.forms["users"].reloadRequired).toBe(true);
+        expect(store.forms["users"].resetRequired).toBe(false);
+    });
+
+    it("reset() flips resetRequired on the matching filter form", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", {});
+
+        useFormFilterRepository("users").reset();
+
+        expect(store.forms["users"].resetRequired).toBe(true);
+        expect(store.forms["users"].reloadRequired).toBe(false);
+    });
+
+    it("is a no-op when the filter form has not been registered", () => {
+        const store = useFormFilterStore();
+        const repo = useFormFilterRepository("missing");
+
+        expect(() => {
+            repo.reload();
+            repo.reset();
+        }).not.toThrow();
+        expect(store.forms["missing"]).toBeUndefined();
+    });
+});

--- a/src/composables/list/__tests__/index.spec.ts
+++ b/src/composables/list/__tests__/index.spec.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    useListRepository,
+    updateItemKeyValue,
+    updateItemValue,
+    deleteItemValue
+} from "../index";
+
+// The repository is backed by a module-level reactive singleton keyed by
+// string, so every test removes the keys it touches to stay isolated.
+const seed = (key: string, items: any[], totalItems = items.length) => {
+    const repo = useListRepository(key);
+    const list = repo.collectListValues<any>();
+    list.items = items;
+    list.totalItems = totalItems;
+    return { repo, list };
+};
+
+describe("useListRepository", () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        errorSpy.mockRestore();
+        ["a", "b", "c", "d", "e", "f", "users_filter", "posts_filter"].forEach((k) =>
+            useListRepository(k).removeList()
+        );
+    });
+
+    it("collectListValues creates a fresh list with sane defaults", () => {
+        const list = useListRepository("a").collectListValues<any>();
+        expect(list).toEqual({ items: [], totalItems: 0, finished: false, loading: false });
+    });
+
+    it("collectListValues returns the same list instance on subsequent calls", () => {
+        const repo = useListRepository("b");
+        const first = repo.collectListValues<any>();
+        first.items.push({ id: "1" });
+        const second = repo.collectListValues<any>();
+        expect(second).toBe(first);
+        expect(second.items).toHaveLength(1);
+    });
+
+    it("removeList drops the list so the next collect recreates it empty", () => {
+        const repo = useListRepository("c");
+        const first = repo.collectListValues<any>();
+        first.items.push({ id: "1" });
+        repo.removeList();
+        const recreated = repo.collectListValues<any>();
+        expect(recreated.items).toHaveLength(0);
+        expect(recreated).not.toBe(first);
+    });
+
+    it("updateListItemValue replaces the whole item when no key is given", () => {
+        const { repo, list } = seed("d", [{ id: "1", name: "ann" }]);
+        repo.updateListItemValue("1", { id: "1", name: "bob" });
+        expect(list.items[0]).toEqual({ id: "1", name: "bob" });
+    });
+
+    it("updateListItemValue updates a single field when a key is given", () => {
+        const { repo, list } = seed("d", [{ id: "1", name: "ann", active: false }]);
+        repo.updateListItemValue("1", true, "active");
+        expect(list.items[0]).toEqual({ id: "1", name: "ann", active: true });
+    });
+
+    it("deleteListItemValue removes the matching item and decrements totalItems", () => {
+        const { repo, list } = seed("e", [{ id: "1" }, { id: "2" }], 2);
+        repo.deleteListItemValue("1");
+        expect(list.items).toEqual([{ id: "2" }]);
+        expect(list.totalItems).toBe(1);
+    });
+
+    it("logs an error (and does not throw) when operating on a non-existent list", () => {
+        const repo = useListRepository("f"); // never collected -> no list
+        expect(() => repo.updateListItemValue("1", "x")).not.toThrow();
+        expect(() => repo.deleteListItemValue("1")).not.toThrow();
+        expect(errorSpy).toHaveBeenCalledWith("Item id not exist");
+    });
+
+    describe("global filter-scoped helpers (append `_filter` to the id)", () => {
+        it("updateItemKeyValue updates a single field on the *_filter list", () => {
+            const { list } = seed("users_filter", [{ id: "1", status: "off" }]);
+            updateItemKeyValue("users", "1", "status", "on");
+            expect(list.items[0].status).toBe("on");
+        });
+
+        it("updateItemValue replaces the whole item on the *_filter list", () => {
+            const { list } = seed("users_filter", [{ id: "1", name: "ann" }]);
+            updateItemValue("users", "1", { id: "1", name: "bob" });
+            expect(list.items[0]).toEqual({ id: "1", name: "bob" });
+        });
+
+        it("deleteItemValue removes the item from the *_filter list", () => {
+            const { list } = seed("posts_filter", [{ id: "1" }, { id: "2" }], 2);
+            deleteItemValue("posts", "1");
+            expect(list.items).toEqual([{ id: "2" }]);
+            expect(list.totalItems).toBe(1);
+        });
+    });
+});

--- a/src/composables/message/__tests__/index.spec.ts
+++ b/src/composables/message/__tests__/index.spec.ts
@@ -1,0 +1,50 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useMessageInstance } from "../index";
+import { useMessageStore } from "../../../store/reactivity/message";
+
+// `useMessageInstance` returns a process-wide singleton that captures the
+// message store on first construction. We therefore install a single pinia
+// for the whole file, force the singleton to bind to it, and reset the
+// store's contents between tests rather than swapping pinia instances.
+describe("useMessageInstance", () => {
+    beforeAll(() => {
+        setActivePinia(createPinia());
+        useMessageInstance(); // bind the singleton's store to this pinia
+    });
+
+    beforeEach(() => {
+        const store = useMessageStore();
+        store.items.splice(0);
+        store.id = 1;
+    });
+
+    it("returns the same singleton instance on every call", () => {
+        expect(useMessageInstance()).toBe(useMessageInstance());
+    });
+
+    it("success() adds a message with the success color", () => {
+        useMessageInstance().success("saved");
+        expect(useMessageStore().items).toEqual([{ id: 1, message: "saved", color: "success" }]);
+    });
+
+    it("warning() adds a message with the warning color", () => {
+        useMessageInstance().warning("careful");
+        expect(useMessageStore().items).toEqual([{ id: 1, message: "careful", color: "warning" }]);
+    });
+
+    it("error() adds a message with the error color", () => {
+        useMessageInstance().error("boom");
+        expect(useMessageStore().items).toEqual([{ id: 1, message: "boom", color: "error" }]);
+    });
+
+    it("queues multiple messages in call order", () => {
+        const msg = useMessageInstance();
+        msg.success("a");
+        msg.error("b");
+        expect(useMessageStore().items.map((m) => [m.message, m.color])).toEqual([
+            ["a", "success"],
+            ["b", "error"]
+        ]);
+    });
+});

--- a/src/store/reactivity/__tests__/form.spec.ts
+++ b/src/store/reactivity/__tests__/form.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useFormStore } from "../form";
+
+describe("useFormStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("starts with an empty forms map", () => {
+        const store = useFormStore();
+        expect(store.forms).toEqual({});
+    });
+
+    it("addForm registers a form that is not busy", () => {
+        const store = useFormStore();
+        store.addForm("create-user");
+        expect(store.forms["create-user"]).toEqual({ busy: false });
+    });
+
+    it("removeForm deletes the form", () => {
+        const store = useFormStore();
+        store.addForm("create-user");
+        store.removeForm("create-user");
+        expect(store.forms["create-user"]).toBeUndefined();
+    });
+
+    it("changeBusy(key, true) sets busy synchronously", () => {
+        const store = useFormStore();
+        store.addForm("create-user");
+
+        store.changeBusy("create-user", true);
+        expect(store.forms["create-user"].busy).toBe(true);
+    });
+
+    it("changeBusy(key, false) clears busy after a 100ms debounce", () => {
+        const store = useFormStore();
+        store.addForm("create-user");
+        store.changeBusy("create-user", true);
+
+        store.changeBusy("create-user", false);
+        // still busy immediately after the call
+        expect(store.forms["create-user"].busy).toBe(true);
+
+        vi.advanceTimersByTime(100);
+        expect(store.forms["create-user"].busy).toBe(false);
+    });
+
+    it("changeBusy(key, true) is a no-op for an unknown form", () => {
+        const store = useFormStore();
+        store.changeBusy("missing", true);
+        expect(store.forms["missing"]).toBeUndefined();
+    });
+
+    it("changeBusy(key, false) does not create a missing form after the debounce", () => {
+        const store = useFormStore();
+        store.changeBusy("missing", false);
+        vi.advanceTimersByTime(100);
+        expect(store.forms["missing"]).toBeUndefined();
+    });
+});

--- a/src/store/reactivity/__tests__/formFiler.spec.ts
+++ b/src/store/reactivity/__tests__/formFiler.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useFormFilterStore } from "../formFiler";
+
+describe("useFormFilterStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("starts with an empty forms map", () => {
+        const store = useFormFilterStore();
+        expect(store.forms).toEqual({});
+    });
+
+    it("addForm creates an entry with the values and default flags", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", { search: "ann" });
+
+        expect(store.forms["users"]).toEqual({
+            values: { search: "ann" },
+            resetRequired: false,
+            reloadRequired: false
+        });
+    });
+
+    it("addForm overwrites an existing key", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", { search: "ann" });
+        store.addForm("users", { search: "bob" });
+
+        expect(store.forms["users"].values).toEqual({ search: "bob" });
+    });
+
+    it("removeForm deletes the entry", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", { search: "ann" });
+        store.removeForm("users");
+
+        expect(store.forms["users"]).toBeUndefined();
+    });
+
+    it("updateValues replaces the values of an existing form", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", { search: "ann" });
+        store.updateValues("users", { search: "bob", page: 2 });
+
+        expect(store.forms["users"].values).toEqual({ search: "bob", page: 2 });
+    });
+
+    it("updateValues is a no-op when the key does not exist", () => {
+        const store = useFormFilterStore();
+        store.updateValues("missing", { search: "x" });
+
+        expect(store.forms["missing"]).toBeUndefined();
+    });
+
+    it("setReloadValue toggles reloadRequired only for an existing form", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", {});
+
+        store.setReloadValue("users", true);
+        expect(store.forms["users"].reloadRequired).toBe(true);
+
+        store.setReloadValue("users", false);
+        expect(store.forms["users"].reloadRequired).toBe(false);
+
+        // no-op for unknown key (must not create one)
+        store.setReloadValue("missing", true);
+        expect(store.forms["missing"]).toBeUndefined();
+    });
+
+    it("setResetValue toggles resetRequired only for an existing form", () => {
+        const store = useFormFilterStore();
+        store.addForm("users", {});
+
+        store.setResetValue("users", true);
+        expect(store.forms["users"].resetRequired).toBe(true);
+
+        store.setResetValue("users", false);
+        expect(store.forms["users"].resetRequired).toBe(false);
+
+        store.setResetValue("missing", true);
+        expect(store.forms["missing"]).toBeUndefined();
+    });
+});

--- a/src/store/reactivity/__tests__/message.spec.ts
+++ b/src/store/reactivity/__tests__/message.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useMessageStore } from "../message";
+
+describe("useMessageStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("starts empty with the id counter at 1", () => {
+        const store = useMessageStore();
+        expect(store.items).toEqual([]);
+        expect(store.id).toBe(1);
+    });
+
+    it("addMessage appends items with auto-incrementing ids", () => {
+        const store = useMessageStore();
+        store.addMessage({ message: "saved", color: "success" });
+        store.addMessage({ message: "careful", color: "warning" });
+
+        expect(store.items).toEqual([
+            { id: 1, message: "saved", color: "success" },
+            { id: 2, message: "careful", color: "warning" }
+        ]);
+        expect(store.id).toBe(3);
+    });
+
+    it("itemsArray getter mirrors items", () => {
+        const store = useMessageStore();
+        store.addMessage({ message: "hi", color: "info" });
+        expect(store.itemsArray).toEqual(store.items);
+        expect(store.itemsArray).toHaveLength(1);
+    });
+
+    it("removeMessage removes the oldest item (FIFO)", () => {
+        const store = useMessageStore();
+        store.addMessage({ message: "first", color: "success" });
+        store.addMessage({ message: "second", color: "error" });
+
+        store.removeMessage();
+
+        expect(store.items).toEqual([{ id: 2, message: "second", color: "error" }]);
+    });
+
+    it("removeMessage on an empty queue is a safe no-op", () => {
+        const store = useMessageStore();
+        expect(() => store.removeMessage()).not.toThrow();
+        expect(store.items).toEqual([]);
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         },
         globals: true,
         environment: 'jsdom',
+        setupFiles: ['./vitest.setup.ts'],
         transformMode: {
             web: [/.[tj]sx$/]
         }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,64 @@
+// Global polyfills for running Vuetify components under jsdom.
+// jsdom does not implement these browser APIs that several Vuetify
+// components (VProgressCircular, VList, VOverlay, useDisplay, ...) rely on.
+
+class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+class IntersectionObserverStub {
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds = [];
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+        return [];
+    }
+}
+
+if (!("ResizeObserver" in globalThis)) {
+    globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+}
+
+if (!("IntersectionObserver" in globalThis)) {
+    globalThis.IntersectionObserver =
+        IntersectionObserverStub as unknown as typeof IntersectionObserver;
+}
+
+if (typeof window !== "undefined" && !window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent() {
+            return false;
+        }
+    })) as unknown as typeof window.matchMedia;
+}
+
+// VOverlay's location strategies (used by VDialog / VMenu / VTooltip) read
+// window.visualViewport, which jsdom does not provide.
+if (typeof window !== "undefined" && !("visualViewport" in window)) {
+    (window as unknown as { visualViewport: unknown }).visualViewport = {
+        width: 1024,
+        height: 768,
+        offsetLeft: 0,
+        offsetTop: 0,
+        pageLeft: 0,
+        pageTop: 0,
+        scale: 1,
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent() {
+            return false;
+        }
+    };
+}


### PR DESCRIPTION
Add a Vitest suite (21 files, 92 tests) covering the Vq* components, the list/form/message composables and the reactivity stores. Includes a jsdom polyfill setup file (ResizeObserver/IntersectionObserver/ matchMedia/visualViewport) so Vuetify overlay and loading components render under test, and verifies the VqDataTable itemsPerPage/sortBy binding end-to-end.