### PR TITLE
fix: import VFileUpload from vuetify/components for Vuetify 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         "vitest": "^4.1.7",
         "vue-router": "^5.0.7",
         "vue-tsc": "^3.3.2",
-        "vuetify": "^4.0.7",
+        "vuetify": "^4.1.0",
         "webfontloader": "^1.6.28",
         "yup": "^1.7.1"
     },
@@ -135,7 +135,7 @@
         "pinia": "3.x",
         "vee-validate": "*",
         "vue": "*",
-        "vuetify": "^4.0.0",
+        "vuetify": "^4.1.0",
         "yup": "*"
     },
     "peerDependenciesMeta": {

--- a/src/components/Vuetify/VqFileUpload/index.tsx
+++ b/src/components/Vuetify/VqFileUpload/index.tsx
@@ -1,6 +1,6 @@
 import { defineComponent, toRef } from "vue";
 import { useField } from "vee-validate";
-import { VFileUpload } from "vuetify/labs/VFileUpload";
+import { VFileUpload } from "vuetify/components";
 
 export const VqFileUpload = defineComponent({
     name: "VqFileUpload",


### PR DESCRIPTION
Vuetify 4.1.0 promoted v-file-upload from labs into the core framework and removed the vuetify/labs/VFileUpload entry point. Update VqFileUpload to import VFileUpload from vuetify/components and bump the vuetify dev and peer dependency to ^4.1.0 accordingly.